### PR TITLE
generalise file locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,14 @@
 .POSIX:
 BIN_DIR = /usr/local/bin
 install: clean
-	@mkdir -p $(BIN_DIR)
-	@for script in src/*; do \
-		cp -f $$script $(BIN_DIR); \
-		chmod 755 $(BIN_DIR)/$${script#src/}; \
-		done
-	@echo Done installing the executable files.
+	@install -D --mode=755 --target-directory=${BIN_DIR} src/faint{,-{bookmark,explore,fetch-config,operate}}
+	@install -D --mode=444 --target-directory=/usr/share/faint src/faint-config
+	@echo Done installing.
 uninstall:
 	@for script in src/*;do rm -f $(BIN_DIR)/$${script#src/}; done
-	@echo Done removing executable files.
+	@unlink /usr/share/faint/faint-config
+	@rmdir /usr/share/faint
+	@echo Done removing.
 clean:
 	@rm -f ~/.local/share/faint/FAINT_FILTERS
 .PHONY: install uninstall clean

--- a/src/faint
+++ b/src/faint
@@ -12,9 +12,13 @@
 #        faint -l (explores the last visited directory)
 #        faint -h (shows help)
 
-. faint-config
+if [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config" ]; then
+  source "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
+else
+  source /usr/share/faint/faint-config
+fi
 
-DATA_PATH=$HOME/.local/share/faint
+DATA_PATH="${XDG_DATA_HOME:-$HOME/.local/share}/faint"
 export FINAL_PATH=$DATA_PATH/FAINT_FINAL
 export FILTERS_PATH=$DATA_PATH/FAINT_FILTERS
 export BOOKMARKS_PATH=$DATA_PATH/FAINT_BOOKMARKS

--- a/src/faint
+++ b/src/faint
@@ -13,9 +13,9 @@
 #        faint -h (shows help)
 
 if [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config" ]; then
-  source "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
 else
-  source /usr/share/faint/faint-config
+  . /usr/share/faint/faint-config
 fi
 
 DATA_PATH="${XDG_DATA_HOME:-$HOME/.local/share}/faint"

--- a/src/faint-bookmark
+++ b/src/faint-bookmark
@@ -5,9 +5,9 @@
 # Dependencies: fzf, sed, faint-config & faint-fetch-config
 
 if [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config" ]; then
-  source "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
 else
-  source /usr/share/faint/faint-config
+  . /usr/share/faint/faint-config
 fi
 
 export FZF_DEFAULT_OPTS="\

--- a/src/faint-bookmark
+++ b/src/faint-bookmark
@@ -4,7 +4,11 @@
 #
 # Dependencies: fzf, sed, faint-config & faint-fetch-config
 
-. faint-config
+if [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config" ]; then
+  source "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
+else
+  source /usr/share/faint/faint-config
+fi
 
 export FZF_DEFAULT_OPTS="\
    $FZF_DEFAULT_OPTS

--- a/src/faint-explore
+++ b/src/faint-explore
@@ -4,7 +4,11 @@
 #
 # Dependencie: find, sort, pkill, faint-launch, faint-config & faint-fetch-config
 
-. faint-config
+if [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config" ]; then
+  source "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
+else
+  source /usr/share/faint/faint-config
+fi
 
 format() {
    while read -r file; do

--- a/src/faint-explore
+++ b/src/faint-explore
@@ -5,9 +5,9 @@
 # Dependencie: find, sort, pkill, faint-launch, faint-config & faint-fetch-config
 
 if [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config" ]; then
-  source "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
 else
-  source /usr/share/faint/faint-config
+  . /usr/share/faint/faint-config
 fi
 
 format() {

--- a/src/faint-operate
+++ b/src/faint-operate
@@ -4,7 +4,11 @@
 #
 # Dependencies: fzf, faint-config & faint-fetch-config
 
-. faint-config
+if [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config" ]; then
+  source "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
+else
+  source /usr/share/faint/faint-config
+fi
 
 export FZF_DEFAULT_OPTS="\
    $FZF_DEFAULT_OPTS

--- a/src/faint-operate
+++ b/src/faint-operate
@@ -5,9 +5,9 @@
 # Dependencies: fzf, faint-config & faint-fetch-config
 
 if [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config" ]; then
-  source "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
+  . "${XDG_CONFIG_HOME:-$HOME/.config}/faint/config"
 else
-  source /usr/share/faint/faint-config
+  . /usr/share/faint/faint-config
 fi
 
 export FZF_DEFAULT_OPTS="\


### PR DESCRIPTION
Installs default config to /usr/share/faint/ and adds XDG Base Directory
Support [1]. Each user may have their own config at
$XDG_CONFIG_HOME/faint/config, with $XDG_CONFIG_HOME defaulting to ~/.config.
The DATA_PATH respects the XDG Base specification.

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html